### PR TITLE
Gym version compatibility issue; updated install setup and instructions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Models
+train/
+raw/
+gifs/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ RAD-A2C architecture and proximal policy optimization (PPO) for radiation source
 
 
 The obstructions (gray rectangles) block line of sight between the detector and gamma source resulting in the detector only measuring background radiation. The left plot shows the detector positions (black triangles) in the environment, the agent's source location prediction (magenta circles), and the gamma source (red star). The middle plot shows the measured gamma radiation intensity at each timestep and the right plot show the cumulative reward that the agent receives from its selected actions during an episode that is used during training to update the neural network weights. The episode terminates if the detector comes within 1.1 m of the gamma source (success) or if the episode length reaches 120 samples (failure).
+
+## Pre-Installation
+Install Swig with `sudo apt install swig` or by following [these instructions](https://github.com/swig/swig/wiki/Getting-Started) - required for VisiLibity library, used in the RadSearch environment.
+
 ## Installation
 It is recommended to use the Anaconda package manager. 
 1. After cloning this repository, create a virtual environment with the required packages 

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,6 @@ dependencies:
   - mpi4py
   - joblib
   - statsmodels
-  - gym
   - matplotlib
   - numba
   - pandas

--- a/eval/test_policy.py
+++ b/eval/test_policy.py
@@ -363,7 +363,11 @@ def run_policy(env, env_set, render=True, save_gif=False, save_path=None,
     stat_buff = core.StatBuff()
     stat_buff.update(o[0])
 
-    max_ep_len= env._max_episode_steps
+    try:
+        max_ep_len= env._max_episode_steps
+    except:
+        max_ep_len= env.env._max_episode_steps
+
    
     #Set the algorithm that will be used for action selection
     get_action = select_model(save_path, ac_kwargs, bp_kwargs, grad_kwargs, model=control, 
@@ -534,7 +538,11 @@ if __name__ == '__main__':
     #Load set of test envs 
     env = make_env(rng,args.num_obs)
     env_path = env_fpath + str(args.num_obs) if args.snr is None else env_fpath + str(args.num_obs)+'_'+args.snr+'_v4'
-    env_set = joblib.load(env_path)
+
+    try:
+        env_set = joblib.load(env_path)
+    except:
+        env_set = joblib.load(f'eval/{env_path}')
 
     #Model parameters, must match the model being loaded
     ac_kwargs = {'batch_s': 1, 'hidden': [24], 'hidden_sizes_pol': [32], 'hidden_sizes_rec': [24], 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 #-e file:///gym_rad_search/
 -e .
 git+https://github.com/peproctor/PyVisiLibity.git
+gym==0.20.0


### PR DESCRIPTION
Updated install to gym 0.20.0 to ensure environment compatibility (gym v0.21.0-v0.24.0 do not work with this environment - see https://github.com/openai/gym/issues/2840#issuecomment-1139312194 for further information). 

Clarified readme to include swig install instructions and created minor error-handling for working directory issue

